### PR TITLE
Slightly improve ListT instance

### DIFF
--- a/src/Data/Unfolder.hs
+++ b/src/Data/Unfolder.hs
@@ -175,7 +175,10 @@ instance (Functor m, Monad m, Error e) => Unfolder (ErrorT e m)
 
 -- | Derived instance.
 instance Applicative f => Unfolder (ListT f) where
-  choose ms = ListT $ concat <$> traverse runListT ms
+  {-# INLINABLE choose #-}
+  choose = ListT . foldr appRun (pure [])
+    where
+      appRun x ys = (++) <$> runListT x <*> ys
   chooseInt n = ListT $ pure [0 .. n - 1]
 
 -- | Derived instance.


### PR DESCRIPTION
`Control.Monad.Trans.List` is pretty broken, but if we're going to
support it we might as well make its `Unfolder` instance as good as
possible. By manually inlining `traverse` for `[]`, we can cut one
`fmap` invocation and avoid allocating conses only to throw them away.
We can also use `foldr` to (hopefully) allow a tiny bit of list fusion.
I haven't actually benchmarked this, but I'm pretty sure it makes good
sense.