### PR TITLE
Improve Unfolder (MaybeT m)

### DIFF
--- a/src/Data/Unfolder.hs
+++ b/src/Data/Unfolder.hs
@@ -139,8 +139,7 @@ instance Unfolder [] where
 
 -- | Always choose the first item.
 instance Unfolder Maybe where
-  choose [] = Nothing
-  choose ms = head ms
+  choose = foldr const Nothing
   chooseInt 0 = Nothing
   chooseInt _ = Just 0
 
@@ -180,7 +179,13 @@ instance Applicative f => Unfolder (ListT f) where
 
 -- | Derived instance.
 instance (Functor m, Monad m) => Unfolder (MaybeT m) where
-  choose ms = MaybeT $ listToMaybe . catMaybes <$> mapM runMaybeT ms
+  choose [] = MaybeT (return Nothing)
+  choose (m : ms) = MaybeT $ do
+    res <- runMaybeT m
+    case res of
+      Nothing -> runMaybeT $ choose ms
+      Just _ -> res <$ mapM_ runMaybeT ms
+
   chooseInt 0 = MaybeT $ return Nothing
   chooseInt _ = MaybeT $ return (Just 0)
   


### PR DESCRIPTION
* Previously, `choose` for `MaybeT m` would build a list
of `Maybe`s within the `Monad` and then find the first
`Just`. Building such a list is pretty much never optimal.
Instead, run the monadic actions one by one, discarding
`Nothing`s. Once a `Just` is reached, use `mapM_` to run
the rest of the actions without saving the results.

* Avoid using `head` for `Unfolder []`.