### PR TITLE
Updated `random` dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ dist-newstyle/
 *.o
 *.p_hi
 *.prof
+stack.yaml*

--- a/unfoldable.cabal
+++ b/unfoldable.cabal
@@ -42,7 +42,7 @@ library
       base         >= 4   && < 5
     , containers   >= 0.5 && < 0.7
     , transformers >= 0.4 && < 0.6
-    , random       >= 1.0 && < 1.2
+    , random       >= 1.0 && < 1.3
     , QuickCheck   >= 2.7.3 && < 3.0
 
   if impl(ghc >= 7.6) && impl(ghc < 9)


### PR DESCRIPTION
There isn't a breaking change by updating the upper bound of `random` to `<1.3`; I've adjusted the Cabal file to reflect this, allowing for better integration for other packages. Also, I've opted to add `stack.yaml*` into `.gitignore` to reflect the package author's lack of stack integration.